### PR TITLE
Includes skip_path option to avoid collecting metrics for specific paths

### DIFF
--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -56,6 +56,7 @@ class PrometheusMiddleware:
         self.kwargs = {}
         if buckets is not None:
             self.kwargs['buckets'] = buckets
+        self.skip_paths = []
         if skip_paths is not None:
             self.skip_paths = skip_paths
 

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -53,10 +53,11 @@ class PrometheusMiddleware:
         self.app_name = app_name
         self.prefix = prefix
         self.filter_unhandled_paths = filter_unhandled_paths
-        self.skip_paths = skip_paths
         self.kwargs = {}
         if buckets is not None:
             self.kwargs['buckets'] = buckets
+        if skip_paths is not None:
+            self.skip_paths = skip_paths
 
     # Starlette initialises middleware multiple times, so store metrics on the class
     @property

--- a/starlette_exporter/middleware.py
+++ b/starlette_exporter/middleware.py
@@ -46,12 +46,14 @@ class PrometheusMiddleware:
         self, app: ASGIApp, group_paths: bool = False, app_name: str = "starlette",
         prefix: str = "starlette", buckets: Optional[List[str]] = None,
         filter_unhandled_paths: bool = False,
+        skip_paths: Optional[List[str]] = None,
     ):
         self.app = app
         self.group_paths = group_paths
         self.app_name = app_name
         self.prefix = prefix
         self.filter_unhandled_paths = filter_unhandled_paths
+        self.skip_paths = skip_paths
         self.kwargs = {}
         if buckets is not None:
             self.kwargs['buckets'] = buckets
@@ -101,6 +103,11 @@ class PrometheusMiddleware:
 
         method = request.method
         path = request.url.path
+
+        if path in self.skip_paths:
+            await self.app(scope, receive, send)
+            return
+
         begin = time.perf_counter()
         end = None
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -52,9 +52,9 @@ def testapp():
             task = BackgroundTask(backgroundtask)
             return JSONResponse({"message": "task started"}, background=task)
 
-#        @app.route("/health")
-#        def healthcheck(request):
-#            return JSONResponse({"message": "Healthcheck route"})
+        @app.route("/health")
+        def healthcheck(request):
+            return JSONResponse({"message": "Healthcheck route"})
 
         # testing routes added using Mount
         async def test_mounted_function(request):
@@ -318,15 +318,15 @@ class TestMiddleware:
             in metrics
         )
 
-    # def test_skip_paths(self, testapp):
-    #     """ test that requests doesn't appear in the counter """
-    #     client = TestClient(testapp(skip_paths=['/health']))
-    #     client.get('/health')
-    #     metrics = client.get('/metrics').content.decode()
-    #     assert (
-    #         """path="/health"""
-    #         not in metrics
-    #     )
+    def test_skip_paths(self, testapp):
+        """ test that requests doesn't appear in the counter """
+        client = TestClient(testapp(skip_paths=['/health']))
+        client.get('/health')
+        metrics = client.get('/metrics').content.decode()
+        assert (
+            """path="/health"""
+            not in metrics
+        )
 
 
 class TestMiddlewareGroupedPaths:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -52,6 +52,10 @@ def testapp():
             task = BackgroundTask(backgroundtask)
             return JSONResponse({"message": "task started"}, background=task)
 
+        @app.route("/health")
+        def normal_response(request):
+            return JSONResponse({"message": "Healthcheck route"})
+
         # testing routes added using Mount
         async def test_mounted_function(request):
             return JSONResponse({"message": "Hello World"})
@@ -312,6 +316,16 @@ class TestMiddleware:
         assert (
             """starlette_requests_in_progress{app_name="starlette",method="GET"} 1.0"""
             in metrics
+        )
+
+    def test_skip_paths(self, testapp):
+        """ test that requests doesn't appear in the counter """
+        client = TestClient(testapp(skip_paths=['/health']))
+        client.get('/health')
+        metrics = client.get('/metrics').content.decode()
+        assert (
+            """path="/health"""
+            not in metrics
         )
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -52,9 +52,9 @@ def testapp():
             task = BackgroundTask(backgroundtask)
             return JSONResponse({"message": "task started"}, background=task)
 
-        @app.route("/health")
-        def healthcheck(request):
-            return JSONResponse({"message": "Healthcheck route"})
+#        @app.route("/health")
+#        def healthcheck(request):
+#            return JSONResponse({"message": "Healthcheck route"})
 
         # testing routes added using Mount
         async def test_mounted_function(request):
@@ -318,15 +318,15 @@ class TestMiddleware:
             in metrics
         )
 
-    def test_skip_paths(self, testapp):
-        """ test that requests doesn't appear in the counter """
-        client = TestClient(testapp(skip_paths=['/health']))
-        client.get('/health')
-        metrics = client.get('/metrics').content.decode()
-        assert (
-            """path="/health"""
-            not in metrics
-        )
+    # def test_skip_paths(self, testapp):
+    #     """ test that requests doesn't appear in the counter """
+    #     client = TestClient(testapp(skip_paths=['/health']))
+    #     client.get('/health')
+    #     metrics = client.get('/metrics').content.decode()
+    #     assert (
+    #         """path="/health"""
+    #         not in metrics
+    #     )
 
 
 class TestMiddlewareGroupedPaths:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -53,7 +53,7 @@ def testapp():
             return JSONResponse({"message": "task started"}, background=task)
 
         @app.route("/health")
-        def normal_response(request):
+        def healthcheck(request):
             return JSONResponse({"message": "Healthcheck route"})
 
         # testing routes added using Mount


### PR DESCRIPTION
skip_path allows the user to define a list of paths that will not collect metrics.
This option is useful to avoid the collection of metric for paths like health-checks or the self-exposed path (/metrics for example).